### PR TITLE
Make deprecation notice more actionable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
 # DEPRECATED
 
-`file-loader` equivalent: `file?name=[path][name].[ext]&context=./src`
+Just use `file-loader`: `file?name=[path][name].[ext]&context=./src`. 
+
+Or, to keep a pretty syntax, add this to your `webpack.config.js`:
+
+```javascript
+    resolveLoader: { 
+        alias: {
+            'copy': 'file-loader?name=[path][name].[ext]&context=./src',
+        }
+    },
+```
+
+So you can just do
+
+```javascript
+    require("copy!somedir/myfile.html");
+```
+
+and `src/somedir/myfile.html` will get copied to `<outputPath>/somedir/myfile.html`.
 
 # copy loader for webpack
 


### PR DESCRIPTION
Hi there!

Turns out this loader is the first hit for "copy loader" in my Google filter bubble, and I bet this holds for more people. Not wanting to spread "file?bla=this&moo=that!myfile.html" all over my codebase, i found an alternative configuration that i believe other would-be users of your loader will appreciate. So I added it to your readme.

Also, the depreciation notice isn't on https://www.npmjs.com/package/copy-loader yet, which is where google actually ends up at. Maybe publish a new version to NPM just so the new readme gets updated there, too?
